### PR TITLE
阻止返回按键

### DIFF
--- a/pages/components/jj-messagebox/messageView/app-message-view.vue
+++ b/pages/components/jj-messagebox/messageView/app-message-view.vue
@@ -15,6 +15,13 @@
 		mounted(){
 			this.currentIndex = this.getCurrentIndex()
 		},
+		onBackPress(options) {
+			if (options.from === 'navigateBack') {
+				return false;
+			}
+			// 返回值为 true, 表示阻止该返回事件，不执行默认的返回
+			return true;
+		},
 		data(){
 			return{
 				currentIndex:-99,


### PR DESCRIPTION
显示`loading`、`alert`时阻止用户按返回键，阻止用户进行UI交互。 fixes #3 

NOTE: `Toast`等组件可能需要允许用户按下返回，请作者另行修改代码，可在组件进行传参来控制此功能开关。